### PR TITLE
added nprob option for index searcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-#ignore big mgf test file
-*.mgf
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+#ignore big mgf test file
+*.mgf
+
 # C extensions
 *.so
 

--- a/dleamse/dleamse_faiss_index_search.py
+++ b/dleamse/dleamse_faiss_index_search.py
@@ -133,7 +133,7 @@ class FaissIndexSearch:
                              columns=["query_id", "limit_num", "result"])
     result_df.to_csv(outpath, index=False)
 
-  def upper_range_search(self, index_path, index_ids_usi_file, embedded, lower_t, threshold, outpath="faiss_range_search_result.csv"):
+  def upper_range_search(self, index_path, index_ids_usi_file, embedded, lower_t, threshold, nprobe, outpath="faiss_range_search_result.csv"):
     """
         Range Search can only use in CPU
         :param outpath:
@@ -147,6 +147,7 @@ class FaissIndexSearch:
     index = faiss.read_index(index_path)  # cpu
     dist = threshold  # Threshold
     query_id, limit_num, result_list = [], [], []
+    index.nprobe = nprobe
     print("The number of query embedded spectra : {}".format(embedded.shape[0]))
     result = index.range_search(embedded, dist)
     lower_result = index.range_search(embedded, lower_t)
@@ -206,7 +207,7 @@ class FaissIndexSearch:
     #                          columns=["query_id", "limit_num", "result"])
     # result_df.to_csv(outpath, index=False)
 
-  def new_range_search(self, index_path, index_ids_usi_file, embedded, threshold, outpath="faiss_range_search_result.csv"):
+  def new_range_search(self, index_path, index_ids_usi_file, embedded, threshold, nprobe, outpath="faiss_range_search_result.csv"):
     """
         Range Search can only use in CPU
         :param outpath:
@@ -220,6 +221,7 @@ class FaissIndexSearch:
     index = faiss.read_index(index_path)  # cpu
     dist = threshold  # Threshold
 
+    index.nprobe = nprobe
     print("The number of query embedded spectra : {}".format(embedded.shape[0]))
     result = index.range_search(embedded, dist)
 
@@ -252,7 +254,7 @@ class FaissIndexSearch:
     f.write(json_data)
     f.close()
 
-  def execute_range_search(self, index_file, index_ids_usi_file, embedded_spectra_file, lower_threshold, upper_threshold, output_file):
+  def execute_range_search(self, index_file, index_ids_usi_file, embedded_spectra_file, lower_threshold, upper_threshold, nprobe, output_file):
 
     print("loading embedded spectra vector...")
     # embedded_arrays = []
@@ -262,11 +264,11 @@ class FaissIndexSearch:
     print("  Read a total of {} spectra".format(run_spectra.shape[0]))
     if lower_threshold == 0:
       print("Runing range search ...")
-      self.new_range_search(index_file, index_ids_usi_file, run_spectra.astype('float32'), upper_threshold, output_file)
+      self.new_range_search(index_file, index_ids_usi_file, run_spectra.astype('float32'), upper_threshold, nprobe, output_file)
       print("Wrote results to {}...".format(output_file))
     elif 0 < lower_threshold < upper_threshold:
       print("Runing upper range search ...")
-      self.upper_range_search(index_file, index_ids_usi_file, run_spectra.astype('float32'), lower_threshold, upper_threshold, output_file)
+      self.upper_range_search(index_file, index_ids_usi_file, run_spectra.astype('float32'), lower_threshold, upper_threshold, nprobe, output_file)
       print("Wrote results to {}...".format(output_file))
     else:
       print("Wrong lower_threshold value, please enter a correct threshold value.")

--- a/dleamse/mslookup.py
+++ b/dleamse/mslookup.py
@@ -16,6 +16,8 @@ from dleamse_faiss_index_writer import FaissWriteIndex
 from dleamse_faiss_index_search import FaissIndexSearch
 from numba.errors import NumbaDeprecationWarning, NumbaPendingDeprecationWarning
 
+DEFAULT_IVF_NLIST = 100
+
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 warnings.simplefilter('ignore', category=NumbaDeprecationWarning)
@@ -98,7 +100,7 @@ def merge_indexes(ctx, input_indexes, output):
 @click.option('--embedded_spectra', '-e', help='Input embedded spectra file', required=True)
 @click.option('--lower_threshold', '-lt', help='Lower radius for range search', default=0)
 @click.option('--upper_threshold', '-ut', help='Upper radius for range search', default=0.07)
-@click.option('--nprobe', '-n', help='Faiss index nprobe', default=64)
+@click.option('--nprobe', '-n', help='Faiss index nprobe', default=DEFAULT_IVF_NLIST)
 @click.option('--output', '-o', help='Output file of range search result', required=True)
 @click.pass_context
 def range_search(ctx, index_file, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, nprobe, output):

--- a/dleamse/mslookup.py
+++ b/dleamse/mslookup.py
@@ -5,10 +5,15 @@ import click
 
 import warnings
 
-from dleamse.dleamse_encode_and_embed import encode_and_embed_spectra
-from dleamse.dleamse_encode_and_embed import SiameseNetwork2
-from dleamse.dleamse_faiss_index_writer import FaissWriteIndex
-from dleamse.dleamse_faiss_index_search import FaissIndexSearch
+# from dleamse.dleamse_encode_and_embed import encode_and_embed_spectra
+# from dleamse.dleamse_encode_and_embed import SiameseNetwork2
+# from dleamse.dleamse_faiss_index_writer import FaissWriteIndex
+# from dleamse.dleamse_faiss_index_search import FaissIndexSearch
+
+from dleamse_encode_and_embed import encode_and_embed_spectra
+from dleamse_encode_and_embed import SiameseNetwork2
+from dleamse_faiss_index_writer import FaissWriteIndex
+from dleamse_faiss_index_search import FaissIndexSearch
 from numba.errors import NumbaDeprecationWarning, NumbaPendingDeprecationWarning
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -93,9 +98,10 @@ def merge_indexes(ctx, input_indexes, output):
 @click.option('--embedded_spectra', '-e', help='Input embedded spectra file', required=True)
 @click.option('--lower_threshold', '-lt', help='Lower radius for range search', default=0)
 @click.option('--upper_threshold', '-ut', help='Upper radius for range search', default=0.07)
+@click.option('--nprobe', '-n', help='Faiss index nprobe', default=64)
 @click.option('--output', '-o', help='Output file of range search result', required=True)
 @click.pass_context
-def range_search(ctx, index_file, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, output):
+def range_search(ctx, index_file, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, nprobe, output):
   """
   Search into database different spectra file.
   :param ctx: Context environment from click
@@ -106,7 +112,7 @@ def range_search(ctx, index_file, index_ids_usi_file, embedded_spectra, lower_th
   :return:
   """
   index_searcher = FaissIndexSearch()
-  index_searcher.execute_range_search(index_file, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, output)
+  index_searcher.execute_range_search(index_file, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, nprobe, output)
 
 
 cli.add_command(embed_ms_file)


### PR DESCRIPTION
the index was built based on default nlist == 100, if we want to search all neighbors, we have to set the nprob = 100 in searching, which is  which is set as defaulted in this commit.