### PR TITLE
auto-range-search & one-stop range-search

### DIFF
--- a/dleamse/dleamse_encode_and_embed.py
+++ b/dleamse/dleamse_encode_and_embed.py
@@ -778,7 +778,7 @@ def encode_spectra(prj, input_file, reference_spectra, **kw):
     ids_usi_df, vstack_data = mgf_encoder.transform_mgf(prj, input_file, reference_spectra, miss_record)
 
     pd.DataFrame(ids_usi_df).to_csv(ids_usi_save_file, header=True, index=None)
-    np.save(encoded_spectra_save_file, vstack_data)
+    #np.save(encoded_spectra_save_file, vstack_data)
 
     return ids_usi_df, vstack_data
 
@@ -789,7 +789,7 @@ def encode_spectra(prj, input_file, reference_spectra, **kw):
     ids_usi_df, vstack_data = mzml_encoder.transform_mzml(prj, input_file, reference_spectra, miss_record)
 
     pd.DataFrame(ids_usi_df).to_csv(ids_usi_save_file, header=True, index=None)
-    np.save(encoded_spectra_save_file, vstack_data)
+    #np.save(encoded_spectra_save_file, vstack_data)
 
     return ids_usi_df, vstack_data
   else:
@@ -803,7 +803,7 @@ def encode_spectra(prj, input_file, reference_spectra, **kw):
 
     pd.DataFrame(ids_usi_df).to_csv(ids_usi_save_file, header=True, index=None)
     print("start .npy...3")
-    np.save(encoded_spectra_save_file, vstack_data)
+    #np.save(encoded_spectra_save_file, vstack_data)
     print("start .npy...4")
 
     return ids_usi_df, vstack_data

--- a/dleamse/mslookup.py
+++ b/dleamse/mslookup.py
@@ -117,10 +117,133 @@ def range_search(ctx, index_file, index_ids_usi_file, embedded_spectra, lower_th
   index_searcher.execute_range_search(index_file, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, nprobe, output)
 
 
+
+@click.command('auto-range-search', short_help="Commandline to automatically range search query embedded spectra against index file")
+@click.option('--model', '-m', help='Input embedder model file',
+              default="./dleamse_model_references/080802_20_1000_NM500R_model.pkl")
+@click.option('--ref_spectra', '-r', help='Input 500 reference spectra file',
+              default="./dleamse_model_references/0722_500_rf_spectra.mgf")
+@click.option('--project_accession', '-p', help='ProteomeXchange dataset accession', default="Project_ID")
+@click.option('--index_file', '-i', help='Index file',  default="./dleamse_model_references/database.index")
+@click.option('--index_ids_usi_file', '-u', help="Index's ids_usi data file",  default="./dleamse_model_references/database_ids_usi.csv")
+@click.option('--raw_spectra', '-e', help='Input MS File (supported: mzML, MGF, JSON)', required=True)
+@click.option('--lower_threshold', '-lt', help='Lower radius for range search', default=0.0)
+@click.option('--upper_threshold', '-ut', help='Upper radius for range search', default=0.07)
+@click.option('--nprobe', '-n', help='Faiss index nprobe', default=DEFAULT_IVF_NLIST)
+@click.option('--output', '-o', help='Output file of range search result', required=True)
+@click.pass_context
+def auto_range_search(ctx, model, ref_spectra, index_file, project_accession, index_ids_usi_file, raw_spectra, lower_threshold, upper_threshold, nprobe, output):
+  """
+  Automatically search for different spectrum files in the database.
+  python mslookup.py auto-range-search -i ./dleamse_model_references/database.index -u ./dleamse_model_references/database_ids_usi.csv -e testdata/query.json -lt 0.0 -ut 0.099 -o testdata/minor.json
+  python mslookup.py auto-range-search -i ./testdata/db.index -u ./testdata/db_ids_usi.csv -e testdata/query.json -lt 0.0 -ut 0.099 -o testdata/minor.json
+  :param ctx: Context environment from click
+  :param model: Model trained to improve the similarity search
+  :param ref_spectra: reference spectra from spectra cluster.
+  :param project_accession: ProteomeXchange accession for the file
+  :param index_file: Input database
+  :param raw_spectra: raw spectra file to be search
+  :param threshold: threshold to be use for search, default 0.1
+  :param output: out file including all the usi that have been found.
+  :return:
+  """
+
+  #embedded spectra
+  encode_and_embed_spectra(model, ref_spectra, project_accession, raw_spectra)
+  dirname, filename = os.path.split(os.path.abspath(raw_spectra))
+  if raw_spectra.endswith(".mgf"):
+    embedded_spectra = dirname + "/" + str(filename.strip(".mgf")) + "_embedded.txt"
+  elif raw_spectra.endswith(".mzML"):
+    embedded_spectra = dirname + "/" + str(filename.strip(".mzML")) + "_embedded.txt"
+  else:
+    embedded_spectra = dirname + "/" + str(filename.strip(".json")) + "_embedded.txt"
+  #search
+  index_searcher = FaissIndexSearch()
+  index_searcher.execute_range_search(index_file, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, nprobe, output)
+
+
+
+
+
+@click.command('onestop-range-search', short_help="Commandline to one-stop range search query embedded spectra against index file")
+@click.option('--model', '-m', help='Input embedder model file',
+              default="./dleamse_model_references/080802_20_1000_NM500R_model.pkl")
+@click.option('--ref_spectra', '-r', help='Input 500 reference spectra file',
+              default="./dleamse_model_references/0722_500_rf_spectra.mgf")
+@click.option('--project_accession', '-p', help='ProteomeXchange dataset accession', default="Project_ID")
+
+@click.option('--database_ids_usi_file', '-d', help='Input database ids file which is named database_ids_usi.csv',
+              required=True)
+@click.option('--outputdb', '-odb', help='Output index file',required=True)
+
+@click.option('--raw_spectra', '-e', help='Input MS File (supported: mzML, MGF, JSON)', required=True)
+@click.option('--library_spectra', '-ls', help='Input MS File (supported: mzML, MGF, JSON) to create library', required=True)
+@click.option('--lower_threshold', '-lt', help='Lower radius for range search', default=0.0)
+@click.option('--upper_threshold', '-ut', help='Upper radius for range search', default=0.07)
+@click.option('--nprobe', '-n', help='Faiss index nprobe', default=DEFAULT_IVF_NLIST)
+@click.option('--output', '-o', help='Output file of range search result', required=True)
+@click.pass_context
+def onestop_range_search(ctx, model, ref_spectra, project_accession, database_ids_usi_file, outputdb, raw_spectra, library_spectra, lower_threshold, upper_threshold, nprobe, output):
+  """
+  Automatically search for different spectrum files in the database.
+  python mslookup.py onestop-range-search -d testdata/db.csv -odb testdata/db.index -ls testdata/PXD015890_114263_ArchiveSpectrum.json -e testdata/query.json -lt 0.0 -ut 0.099 -o testdata/minor.json
+  python mslookup.py onestop-range-search -d /home/qinchunyuan/528xiyangMakeForTest/test0825/db.csv -odb /home/qinchunyuan/528xiyangMakeForTest/test0825/db.index -ls /home/qinchunyuan/528xiyangMakeForTest/test0825/PXD015890_114263_ArchiveSpectrum.json -e /home/qinchunyuan/528xiyangMakeForTest/test0825/query.json -lt 0.0 -ut 0.099 -o /home/qinchunyuan/528xiyangMakeForTest/test0825/minor.json
+  :param ctx: Context environment from click
+  :param model: Model trained to improve the similarity search
+  :param ref_spectra: reference spectra from spectra cluster.
+  :param project_accession: ProteomeXchange accession for the file
+  :param database_ids_usi_file: database with ids and usi files
+  #:param embedded_spectra_path: embedded spectra 32-vector file.
+  :param outputdb: index file.
+  #:param index_file: Input database
+  :param raw_spectra: raw spectra file to be search
+  :param threshold: threshold to be use for search, default 0.1
+  :param output: out file including all the usi that have been found.
+  :return:
+  """
+
+  dirnamels, filenamels = os.path.split(os.path.abspath(library_spectra))
+  if raw_spectra.endswith(".mgf"):
+    embedded_spectra_path = dirnamels + "/"
+    #outputdb = dirname + "/" + str(filenamels.strip(".mgf")) + "_DB.index"
+  elif raw_spectra.endswith(".mzML"):
+    embedded_spectra_path = dirnamels + "/"
+    #outputdb = dirname + "/" + str(filenamels.strip(".mgf")) + "_DB.index"
+  else:
+    embedded_spectra_path = dirnamels + "/"
+    #outputdb = dirname + "/" + str(filenamels.strip(".mgf")) + "_DB.index"
+
+  if "../" in outputdb:
+  	index_ids_usi_file = ".."+outputdb.strip('.index') + '_ids_usi.csv'
+  else:
+  	index_ids_usi_file = outputdb.strip('index').strip(".") + '_ids_usi.csv'
+  #create library-embedded
+  encode_and_embed_spectra(model, ref_spectra, project_accession, library_spectra)
+  # make index
+  index_maker = FaissWriteIndex()
+  index_maker.create_index_for_embedded_spectra(database_ids_usi_file, embedded_spectra_path, outputdb)
+
+
+  #embedded spectra query
+  encode_and_embed_spectra(model, ref_spectra, project_accession, raw_spectra)
+  dirname, filename = os.path.split(os.path.abspath(raw_spectra))
+  if raw_spectra.endswith(".mgf"):
+    embedded_spectra = dirname + "/" + str(filename.strip(".mgf")) + "_embedded.txt"
+  elif raw_spectra.endswith(".mzML"):
+    embedded_spectra = dirname + "/" + str(filename.strip(".mzML")) + "_embedded.txt"
+  else:
+    embedded_spectra = dirname + "/" + str(filename.strip(".json")) + "_embedded.txt"
+  #search
+  index_searcher = FaissIndexSearch()
+  index_searcher.execute_range_search(outputdb, index_ids_usi_file, embedded_spectra, lower_threshold, upper_threshold, nprobe, output)
+
+
 cli.add_command(embed_ms_file)
 cli.add_command(make_index)
 cli.add_command(merge_indexes)
 cli.add_command(range_search)
+cli.add_command(auto_range_search)
+cli.add_command(onestop_range_search)
 
 if __name__ == "__main__":
   cli()

--- a/dleamse/tests/dleamse_tests.py
+++ b/dleamse/tests/dleamse_tests.py
@@ -62,12 +62,12 @@ def embeded_query_spectra():
   assert result.exit_code == 0
 
 def clean_db():
-  os.remove("testdata/PXD015890_114263_ArchiveSpectrum_encoded.npy")
+  #os.remove("testdata/PXD015890_114263_ArchiveSpectrum_encoded.npy")
   os.remove("testdata/PXD015890_114263_ArchiveSpectrum_ids_usi.txt")
   os.remove("testdata/db.index")
   #os.remove("testdata/usi_db.csv") #No such file was generated
   os.remove("testdata/db_ids_usi.csv")
-  os.remove("testdata/query_encoded.npy")
+  #os.remove("testdata/query_encoded.npy")
   os.remove("testdata/query_ids_usi.txt")
 
 

--- a/dleamse/tests/dleamse_tests2.py
+++ b/dleamse/tests/dleamse_tests2.py
@@ -74,6 +74,21 @@ def clean_db():
   #os.remove(abspath_dleamse+"testdata/query_encoded.npy")
   os.remove(abspath_dleamse+"testdata/query_ids_usi.txt")
 
+def clean_db2():
+  os.remove(abspath_dleamse+"testdata/PXD015890_114263_ArchiveSpectrum_ids_usi.txt")
+  os.remove(abspath_dleamse+"testdata/PXD015890_114263_ArchiveSpectrum_embedded.txt")
+  os.remove(abspath_dleamse+"testdata/db.index")
+  os.remove(abspath_dleamse+"testdata/db_ids_usi.csv")
+  os.remove(abspath_dleamse+"testdata/db.csv")
+  os.remove(abspath_dleamse+"testdata/query_ids_usi.txt")
+  os.remove(abspath_dleamse+"testdata/query_embedded.txt")
+
+def clean_resultfiles():
+  os.remove(abspath_dleamse+"testdata/minor.csv")
+  os.remove(abspath_dleamse+"testdata/minortoautosearch.csv")
+  os.remove(abspath_dleamse+"testdata/minoronestopsearch.csv")
+
+
 
 def search_spectra():
   runner = CliRunner()
@@ -93,10 +108,46 @@ def search_spectra():
   print(result.exit_code)
   assert result.exit_code == 0
 
+
+def auto_search_spectra():
+  runner = CliRunner()
+  result = runner.invoke(cli,
+                         ['auto-range-search', '-i', abspath_dleamse+'testdata/db.index',
+                          '-u', abspath_dleamse+'testdata/db_ids_usi.csv', '-n', 100,'-e', abspath_dleamse+'testdata/query.json', '-o', abspath_dleamse+'testdata/minortoautosearch.csv', '-ut', 0.099, '-lt', 0.0])
+  """
+  python mslookup.py auto-range-search -i ./testdata/db.index -u ./testdata/db_ids_usi.csv -e testdata/query.json -lt 0.0 -ut 0.099 -o testdata/minortoautosearch.json
+  """
+  print(result)
+  print(result.output)
+  print(result.exit_code)
+  assert result.exit_code == 0
+
+
+
+def onestop_search_spectra():
+  runner = CliRunner()
+  result = runner.invoke(cli,
+                         ['onestop-range-search', '-d', abspath_dleamse+'testdata/db.csv', '-odb', abspath_dleamse+'testdata/db.index', '-ls', abspath_dleamse+'testdata/PXD015890_114263_ArchiveSpectrum.json', '-n', 100,'-e', abspath_dleamse+'testdata/query.json', '-o', abspath_dleamse+'testdata/minoronestopsearch.csv', '-ut', 0.099, '-lt', 0.0])
+  """
+  python mslookup.py onestop-range-search -d testdata/db.csv -odb testdata/db.index -ls testdata/PXD015890_114263_ArchiveSpectrum.json -e testdata/query.json -lt 0.0 -ut 0.099 -o testdata/minoronestopsearch.json
+  """
+  print(result)
+  print(result.output)
+  print(result.exit_code)
+  assert result.exit_code == 0
+
+
+
+
 if __name__ == '__main__':
     embeded_db_spectra()
     make_db()
     embeded_query_spectra()
     search_spectra()
-    clean_db()
+    auto_search_spectra()
+    clean_db2()
+    
+    onestop_search_spectra()
+    clean_db2()
+    clean_resultfiles()
 


### PR DESCRIPTION
We have added two new command line APIs: one is auto-range-search: you only need to provide a library file and the original file to get the results with one click; the other is one-stop range-search: the command only needs to be provided by the user A spectrum file for building the library file and a spectrum file for querying can get the results in one click